### PR TITLE
CxSCA-Remediation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "express-session": "^1.13.0",
     "forever": "^2.0.0",
     "helmet": "^2.0.0",
-    "marked": "0.3.9",
-    "mongodb": "^2.1.18",
+    "marked": "2.0.0",
+    "mongodb": "3.1.13",
     "needle": "2.2.4",
     "node-esapi": "0.0.1",
     "serve-favicon": "^2.3.0",
     "swig": "^1.4.2",
-    "underscore": "^1.8.3"
+    "underscore": "1.12.1"
   },
   "comments": {
     "//": "a9 insecure components"
@@ -42,7 +42,7 @@
     "async": "^2.0.0-rc.4",
     "cross-env": "^7.0.2",
     "cypress": "^3.3.1",
-    "grunt": "^1.0.1",
+    "grunt": "1.3.0",
     "grunt-cli": "^1.2.0",
     "grunt-concurrent": "^2.3.0",
     "grunt-contrib-jshint": "^1.0.0",


### PR DESCRIPTION
### Packages updated by CxSCA-Remediation

**package.json:**
 - grunt: 1.0.3 🠚 1.3.0 (Fixes: CVE-2020-7729)
 - marked: 0.3.9 🠚 2.0.0 (Fixes: Cx816df59e-1cc9, Cx3bab5572-419d, Cxee7cbf9f-8b8d)
 - mongodb: 2.2.36 🠚 3.1.13 (Fixes: Cxd6c215a2-86bd)
 - underscore: 1.9.1 🠚 1.12.1 (Fixes: CVE-2021-23358)
